### PR TITLE
Change to patternfly-bootstrap-treeview repository

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   "require": {
     "execut/yii2-base": "*",
     "yiisoft/yii2-jui": "@dev",
-    "bower-asset/bootstrap-treeview": "@dev"
+    "bower-asset/patternfly-bootstrap-treeview": "@dev"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "nerburish/yii2-widget-bootstraptreeview",
+  "name": "execut/yii2-widget-bootstraptreeview",
   "version": "1.1.2",
   "description": "Bootstrap Tree View widget wrapper for yii2",
   "keywords": ["yii2", "extension", "tree", "input", "form", "bootstrap", "jquery", "plugin"],

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "execut/yii2-widget-bootstraptreeview",
+  "name": "nerburish/yii2-widget-bootstraptreeview",
   "version": "1.1.2",
   "description": "Bootstrap Tree View widget wrapper for yii2",
   "keywords": ["yii2", "extension", "tree", "input", "form", "bootstrap", "jquery", "plugin"],


### PR DESCRIPTION
Hi,
Looks like the original repository of bootstrap-treeview is not maintained anymore. Now the changes are done in this repository:
https://github.com/patternfly/patternfly-bootstrap-treeview

Greetings